### PR TITLE
Fix incorrect switch-statement fallthru.

### DIFF
--- a/src/SoftWire.cpp
+++ b/src/SoftWire.cpp
@@ -204,6 +204,7 @@ SoftWire::result_t SoftWire::llStartWait(uint8_t rawAddr) const
 			return ack;
 		case nack:
 			stop();
+			return nack;
 		default:
 			// timeout, and anything else we don't know about
 			stop();


### PR DESCRIPTION
The compiler issues the following warning message:

SoftWire.cpp:206:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
    stop();

And the compiler is correct. The function incorrectly issues 2 stop() conditions,
and returns 'timedOut' instead of 'nack' due to the incorrect fallthru.