### PR TITLE
Fix no data transmitted issue because `_txBufferIndex` always zero

### DIFF
--- a/src/SoftWire.cpp
+++ b/src/SoftWire.cpp
@@ -429,7 +429,7 @@ uint8_t SoftWire::endTransmissionInner(void) const
     else if (r == timedOut)
         return 4;
 
-    for (uint8_t i = 0; i < _txBufferIndex; ++i) {
+    for (uint8_t i = 0; i < _txBufferSize; ++i) {
         r = llWrite(_txBuffer[i]);
         if (r == nack)
             return 3;


### PR DESCRIPTION
### Problem:
The data line wasn't sending any data after the address was sent.
If I got any mistaken for the usage, please guide me.

Thanks for the library and appreciated.😊

### Before fix:
The data line keeps sending the address + write mode with no data afterward. [0x64:W, nothings ... ] 

### After fix:
The data line has data following the first clock, excepted [0x64:W, 00000001, 00000010, 00000011] in this case.

### Simple code to reproduce the problem:
```cpp
#include <Arduino.h>
#include <SoftWire.h>

uint8_t sdaPin = A2;
uint8_t sclPin = A3;
SoftWire i2c(sdaPin, sclPin);

void setup()
{
  i2c.setDelay_us(5);
  i2c.begin();
  delay(300);
}

void loop()
{
  uint8_t data[3] = {1, 2, 3};
  i2c.beginTransmission(0x64);
  i2c.setTxBuffer(data, 3);
  // workaround to increase the _txBufferIndex by calling `write(data, size)`  but waste CPU time. 
  // also the `write(data, size)` must need to call after `setTxBuffer` since `_txBufferIndex >= _txBufferSize` always true
  // i2c.write(data, 3); 
  i2c.endTransmission();
  delay(100);
}
```


`_txBufferIndex >= _txBufferSize` is always true and return for the first write, so `_txBuffer` seems never write.
```cpp
size_t SoftWire::write(uint8_t data)
{
    if (_txBufferIndex >= _txBufferSize) {
        setWriteError();
        return 0;
    }

    _txBuffer[_txBufferIndex++] = data;
    return 1;
}
```

### Screenshots from oscilloscope
before fix:
![image](https://user-images.githubusercontent.com/12498885/137703109-3b23a530-e093-4085-9216-72c1f54dfe91.png)

after fix:
![image](https://user-images.githubusercontent.com/12498885/137703212-5aa8d726-86ff-49e4-b975-3f7cea6d417d.png)
