### PR TITLE
Fix up -Wshadow warnings by changing method argument names

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The AsyncDelay library is required, see
 * [Phonog](https://github.com/Phonog)
 * [Tutoduino](https://github.com/tutoduino)
 * [Brian Park](https://github.com/bxparks)
+* [Wayne Piekarski](https://github.com/waynepiekarski)
 
 ## Credits
 

--- a/src/SoftWire.h
+++ b/src/SoftWire.h
@@ -86,25 +86,25 @@ class SoftWire : public Stream {
 
 
     // Setters to override functions which control the SDA and SCL pins
-    inline void setSetSdaLow(void (*sdaLow)(const SoftWire*)) {
-      _sdaLow = sdaLow;
+    inline void setSetSdaLow(void (*sdaLowFn)(const SoftWire*)) {
+      _sdaLow = sdaLowFn;
     }
-    inline void setSetSdaHigh(void (*sdaHigh)(const SoftWire*)) {
-      _sdaHigh = sdaHigh;
+    inline void setSetSdaHigh(void (*sdaHighFn)(const SoftWire*)) {
+      _sdaHigh = sdaHighFn;
     }
-    inline void setSetSclLow(void (*sclLow)(const SoftWire*)) {
-      _sclLow = sclLow;
+    inline void setSetSclLow(void (*sclLowFn)(const SoftWire*)) {
+      _sclLow = sclLowFn;
     }
-    inline void setSetSclHigh(void (*sclHigh)(const SoftWire*)) {
-      _sclHigh = sclHigh;
+    inline void setSetSclHigh(void (*sclHighFn)(const SoftWire*)) {
+      _sclHigh = sclHighFn;
     }
 
     // Setters to override the functions which read the status of SDA and SCL
-    inline void setReadSda(uint8_t (*readSda)(const SoftWire*)) {
-      _readSda = readSda;
+    inline void setReadSda(uint8_t (*readSdaFn)(const SoftWire*)) {
+      _readSda = readSdaFn;
     }
-    inline void setReadScl(uint8_t (*readScl)(const SoftWire*)) {
-      _readScl = readScl;
+    inline void setReadScl(uint8_t (*readSclFn)(const SoftWire*)) {
+      _readScl = readSclFn;
     }
 
     // Wrapper functions to provide direct compatibility with the Wire library (TwoWire class)


### PR DESCRIPTION
If you are compiling code with -Wshadow then SoftWire will give warnings/errors since there are methods with the same name.